### PR TITLE
Update prism-php/prism version constraints to allow latest versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.2",
         "filament/filament": "^4.0",
         "filament/forms": "^4.0",
-        "prism-php/prism": "^0.97.0",
+        "prism-php/prism": "^0.97.0 || ^0.98.0 || ^0.99.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pr updates the prism-php/prism version constraints to allow latest versions ^0.98 and ^0.99